### PR TITLE
Feat redis cache

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -29,11 +29,14 @@ export default {
       testMatch: ["<rootDir>/tests/unit/middlewares/**/*.test.js"],
       // Load DB mock before modules so middleware tests use the mock
       setupFiles: ["<rootDir>/tests/setupMiddlewareMocks.js"],
+      // Add Redis mock for middleware tests
+      setupFilesAfterEnv: ["<rootDir>/tests/setupRedisMock.js"]
     },
     {
       displayName: "default",
       testMatch: ["<rootDir>/tests/**/*.test.js", "!<rootDir>/tests/unit/middlewares/**/*.test.js"],
-      setupFilesAfterEnv: ["<rootDir>/tests/setupJest.js"]
+      // Load Redis mock for all tests
+      setupFilesAfterEnv: ["<rootDir>/tests/setupJest.js", "<rootDir>/tests/setupRedisMock.js"]
     }
   ],
   

--- a/src/cache/noteCache.js
+++ b/src/cache/noteCache.js
@@ -1,0 +1,287 @@
+import redisClient from './redis.js';
+
+// Cache TTL in seconds
+const DEFAULT_TTL = 60 * 5; // 5 minutes default
+
+/**
+ * Note cache service
+ * Manages cached access to notes with proper invalidation
+ */
+class NoteCache {
+  /**
+   * Generate cache key for user's notes
+   * @param {Number} userId - The user's ID
+   * @returns {String} - Redis key for all notes
+   */
+  getUserNotesKey(userId) {
+    return `user:${userId}:notes`;
+  }
+
+  /**
+   * Generate cache key for a specific note
+   * @param {Number} noteId - The note's ID
+   * @returns {String} - Redis key for the note
+   */
+  getNoteKey(noteId) {
+    return `note:${noteId}`;
+  }
+
+  /**
+   * Generate cache key for note versions
+   * @param {Number} noteId - The note's ID
+   * @returns {String} - Redis key for note versions
+   */
+  getNoteVersionsKey(noteId) {
+    return `note:${noteId}:versions`;
+  }
+
+  /**
+   * Generate cache key for search results
+   * @param {Number} userId - The user's ID
+   * @param {String} query - The search query
+   * @returns {String} - Redis key for search results
+   */
+  getSearchKey(userId, query) {
+    return `user:${userId}:search:${query}`;
+  }
+
+  /**
+   * Cache user's notes
+   * @param {Number} userId - User ID
+   * @param {Array} notes - Array of note objects
+   * @param {Number} ttl - Cache TTL in seconds
+   */
+  async cacheUserNotes(userId, notes, ttl = DEFAULT_TTL) {
+    try {
+      const key = this.getUserNotesKey(userId);
+      await redisClient.setEx(key, ttl, JSON.stringify(notes));
+      console.log(`Cached notes for user ${userId}`);
+    } catch (error) {
+      console.error('Error caching user notes:', error);
+      // Continue execution even if caching fails
+    }
+  }
+
+  /**
+   * Retrieve user's notes from cache
+   * @param {Number} userId - User ID
+   * @returns {Array|null} - Array of note objects or null if not in cache
+   */
+  async getUserNotes(userId) {
+    try {
+      const key = this.getUserNotesKey(userId);
+      const cachedNotes = await redisClient.get(key);
+      
+      if (cachedNotes) {
+        console.log(`Cache hit: notes for user ${userId}`);
+        return JSON.parse(cachedNotes);
+      }
+      
+      console.log(`Cache miss: notes for user ${userId}`);
+      return null;
+    } catch (error) {
+      console.error('Error retrieving user notes from cache:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Cache a single note
+   * @param {Object} note - The note object
+   * @param {Number} ttl - Cache TTL in seconds
+   */
+  async cacheNote(note, ttl = DEFAULT_TTL) {
+    try {
+      const key = this.getNoteKey(note.id);
+      await redisClient.setEx(key, ttl, JSON.stringify(note));
+      console.log(`Cached note ${note.id}`);
+    } catch (error) {
+      console.error('Error caching note:', error);
+    }
+  }
+
+  /**
+   * Retrieve a note from cache
+   * @param {Number} noteId - Note ID
+   * @returns {Object|null} - Note object or null if not in cache
+   */
+  async getNote(noteId) {
+    try {
+      const key = this.getNoteKey(noteId);
+      const cachedNote = await redisClient.get(key);
+      
+      if (cachedNote) {
+        console.log(`Cache hit: note ${noteId}`);
+        return JSON.parse(cachedNote);
+      }
+      
+      console.log(`Cache miss: note ${noteId}`);
+      return null;
+    } catch (error) {
+      console.error('Error retrieving note from cache:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Cache note versions
+   * @param {Number} noteId - Note ID
+   * @param {Array} versions - Array of version objects
+   * @param {Number} ttl - Cache TTL in seconds
+   */
+  async cacheNoteVersions(noteId, versions, ttl = DEFAULT_TTL) {
+    try {
+      const key = this.getNoteVersionsKey(noteId);
+      await redisClient.setEx(key, ttl, JSON.stringify(versions));
+      console.log(`Cached versions for note ${noteId}`);
+    } catch (error) {
+      console.error('Error caching note versions:', error);
+    }
+  }
+
+  /**
+   * Retrieve note versions from cache
+   * @param {Number} noteId - Note ID
+   * @returns {Array|null} - Array of version objects or null if not in cache
+   */
+  async getNoteVersions(noteId) {
+    try {
+      const key = this.getNoteVersionsKey(noteId);
+      const cachedVersions = await redisClient.get(key);
+      
+      if (cachedVersions) {
+        console.log(`Cache hit: versions for note ${noteId}`);
+        return JSON.parse(cachedVersions);
+      }
+      
+      console.log(`Cache miss: versions for note ${noteId}`);
+      return null;
+    } catch (error) {
+      console.error('Error retrieving note versions from cache:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Cache search results
+   * @param {Number} userId - User ID
+   * @param {String} query - Search query
+   * @param {Array} results - Search results
+   * @param {Number} ttl - Cache TTL in seconds
+   */
+  async cacheSearchResults(userId, query, results, ttl = DEFAULT_TTL) {
+    try {
+      const key = this.getSearchKey(userId, query);
+      await redisClient.setEx(key, ttl, JSON.stringify(results));
+      console.log(`Cached search results for user ${userId}, query: "${query}"`);
+    } catch (error) {
+      console.error('Error caching search results:', error);
+    }
+  }
+
+  /**
+   * Retrieve search results from cache
+   * @param {Number} userId - User ID
+   * @param {String} query - Search query
+   * @returns {Array|null} - Search results or null if not in cache
+   */
+  async getSearchResults(userId, query) {
+    try {
+      const key = this.getSearchKey(userId, query);
+      const cachedResults = await redisClient.get(key);
+      
+      if (cachedResults) {
+        console.log(`Cache hit: search results for user ${userId}, query: "${query}"`);
+        return JSON.parse(cachedResults);
+      }
+      
+      console.log(`Cache miss: search results for user ${userId}, query: "${query}"`);
+      return null;
+    } catch (error) {
+      console.error('Error retrieving search results from cache:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Invalidate user's notes cache
+   * @param {Number} userId - User ID
+   */
+  async invalidateUserNotes(userId) {
+    try {
+      const key = this.getUserNotesKey(userId);
+      await redisClient.del(key);
+      console.log(`Invalidated notes cache for user ${userId}`);
+    } catch (error) {
+      console.error('Error invalidating user notes cache:', error);
+    }
+  }
+
+  /**
+   * Invalidate note cache
+   * @param {Number} noteId - Note ID
+   */
+  async invalidateNote(noteId) {
+    try {
+      const key = this.getNoteKey(noteId);
+      await redisClient.del(key);
+      console.log(`Invalidated cache for note ${noteId}`);
+    } catch (error) {
+      console.error('Error invalidating note cache:', error);
+    }
+  }
+
+  /**
+   * Invalidate note versions cache
+   * @param {Number} noteId - Note ID
+   */
+  async invalidateNoteVersions(noteId) {
+    try {
+      const key = this.getNoteVersionsKey(noteId);
+      await redisClient.del(key);
+      console.log(`Invalidated versions cache for note ${noteId}`);
+    } catch (error) {
+      console.error('Error invalidating note versions cache:', error);
+    }
+  }
+
+  /**
+   * Invalidate all caches for a note
+   * @param {Number} noteId - Note ID
+   * @param {Number} userId - User ID
+   */
+  async invalidateAllNoteCache(noteId, userId) {
+    try {
+      await Promise.all([
+        this.invalidateNote(noteId),
+        this.invalidateNoteVersions(noteId),
+        this.invalidateUserNotes(userId)
+      ]);
+      console.log(`Invalidated all caches for note ${noteId}`);
+    } catch (error) {
+      console.error('Error invalidating all note caches:', error);
+    }
+  }
+
+  /**
+   * Invalidate search results cache
+   * @param {Number} userId - User ID
+   */
+  async invalidateSearchResults(userId) {
+    try {
+      // Get all search keys for this user
+      const pattern = `user:${userId}:search:*`;
+      const keys = await redisClient.keys(pattern);
+      
+      if (keys.length > 0) {
+        await redisClient.del(keys);
+        console.log(`Invalidated ${keys.length} search result caches for user ${userId}`);
+      }
+    } catch (error) {
+      console.error('Error invalidating search results cache:', error);
+    }
+  }
+}
+
+// Export as singleton
+export default new NoteCache();

--- a/src/controllers/noteController.js
+++ b/src/controllers/noteController.js
@@ -1,5 +1,6 @@
 import { db } from '../config/database.js';
 import { asyncHandler, NotFoundError, ConflictError } from '../middlewares/errorHandler.js';
+import noteCache from '../cache/noteCache.js';
 
 /**
  * Create a new note
@@ -26,6 +27,9 @@ export const createNote = asyncHandler(async (req, res) => {
     createdBy: userId
   });
   
+  // Invalidate user's notes cache since we added a new note
+  await noteCache.invalidateUserNotes(userId);
+  
   return res.status(201).json(note);
 });
 
@@ -34,7 +38,14 @@ export const createNote = asyncHandler(async (req, res) => {
  */
 export const getAllNotes = asyncHandler(async (req, res) => {
   const userId = req.user.id;
-  // Get notes from database
+  
+  // Try to get from cache first
+  const cachedNotes = await noteCache.getUserNotes(userId);
+  if (cachedNotes) {
+    return res.json(cachedNotes);
+  }
+  
+  // If not in cache, get notes from database
   const notes = await db.Note.findAll({
     where: {
       userId,
@@ -42,6 +53,9 @@ export const getAllNotes = asyncHandler(async (req, res) => {
     },
     order: [['updatedAt', 'DESC']]
   });
+  
+  // Store in cache for future requests
+  await noteCache.cacheUserNotes(userId, notes);
   
   return res.json(notes);
 });
@@ -52,7 +66,14 @@ export const getAllNotes = asyncHandler(async (req, res) => {
 export const getNoteById = asyncHandler(async (req, res) => {
   const noteId = req.params.id;
   const userId = req.user.id;
-  // Get note from database
+  
+  // Try to get from cache first
+  const cachedNote = await noteCache.getNote(noteId);
+  if (cachedNote && cachedNote.userId === userId && !cachedNote.isDeleted) {
+    return res.json(cachedNote);
+  }
+  
+  // If not in cache, get note from database
   const note = await db.Note.findOne({
     where: {
       id: noteId,
@@ -65,6 +86,9 @@ export const getNoteById = asyncHandler(async (req, res) => {
     throw new NotFoundError('Note not found');
   }
 
+  // Store in cache for future requests
+  await noteCache.cacheNote(note);
+
   return res.json(note);
 });
 
@@ -74,6 +98,16 @@ export const getNoteById = asyncHandler(async (req, res) => {
 export const getNoteVersions = asyncHandler(async (req, res) => {
   const noteId = req.params.id;
   const userId = req.user.id;
+  
+  // Try to get versions from cache first
+  const cachedVersions = await noteCache.getNoteVersions(noteId);
+  if (cachedVersions) {
+    // Still need to verify the note belongs to the user
+    const cachedNote = await noteCache.getNote(noteId);
+    if (cachedNote && cachedNote.userId === userId) {
+      return res.json(cachedVersions);
+    }
+  }
   
   // Check if note belongs to user
   const note = await db.Note.findOne({
@@ -94,6 +128,12 @@ export const getNoteVersions = asyncHandler(async (req, res) => {
     },
     order: [['version', 'DESC']]
   });
+  
+  // Cache note and versions for future requests
+  await Promise.all([
+    noteCache.cacheNote(note),
+    noteCache.cacheNoteVersions(noteId, versions)
+  ]);
   
   return res.json(versions);
 });
@@ -161,6 +201,9 @@ export const revertToVersion = asyncHandler(async (req, res) => {
     }, { transaction });
     
     await transaction.commit();
+    
+    // Invalidate all related caches
+    await noteCache.invalidateAllNoteCache(noteId, userId);
     
     return res.json({
       message: `Successfully reverted to version ${versionNumber}`,
@@ -251,6 +294,9 @@ export const updateNote = asyncHandler(async (req, res) => {
     
     await transaction.commit();
     
+    // Invalidate all related caches
+    await noteCache.invalidateAllNoteCache(noteId, userId);
+    
     return res.json(note);
   } catch (error) {
     // Only roll back if the transaction is still active
@@ -265,29 +311,118 @@ export const updateNote = asyncHandler(async (req, res) => {
  * Search notes by keywords
  */
 export const searchNotes = asyncHandler(async (req, res) => {
-  const query = req.query.q;
   const userId = req.user.id;
+  const { q: searchQuery } = req.query;
   
-  // Search in database
-  // Using LIKE for basic search, would use full-text search in production
-  const notes = await db.Note.findAll({
-    where: {
-      userId,
-      isDeleted: false,
-      [db.Sequelize.Op.or]: [
-        { title: { [db.Sequelize.Op.like]: `%${query}%` } },
-        { content: { [db.Sequelize.Op.like]: `%${query}%` } }
-      ]
-    }
-  });
+  // Try to get from cache first
+  const cachedResults = await noteCache.getSearchResults(userId, searchQuery);
+  if (cachedResults) {
+    return res.json(cachedResults);
+  }
   
-  return res.json(notes);
+  // Use different search strategies based on environment
+  let searchResults;
+  
+  if (process.env.NODE_ENV === 'test') {
+    // For testing (SQLite): Use basic LIKE search that works with SQLite
+    searchResults = await db.Note.findAll({
+      where: {
+        userId,
+        isDeleted: false,
+        [db.Sequelize.Op.or]: [
+          { title: { [db.Sequelize.Op.like]: `%${searchQuery}%` } },
+          { content: { [db.Sequelize.Op.like]: `%${searchQuery}%` } }
+        ]
+      }
+    });
+  } else {
+    // For production (MySQL): Use FULLTEXT search for better performance
+    searchResults = await db.sequelize.query(
+      `SELECT * FROM Notes 
+      WHERE userId = :userId 
+      AND isDeleted = 0 
+      AND MATCH(title, content) AGAINST(:query IN NATURAL LANGUAGE MODE)`,
+      {
+        replacements: { userId, query: searchQuery },
+        type: db.sequelize.QueryTypes.SELECT,
+        model: db.Note
+      }
+    );
+  }
+  
+  // Cache search results
+  await noteCache.cacheSearchResults(userId, searchQuery, searchResults);
+  
+  return res.json(searchResults);
 });
 
 /**
- * Soft delete a note
+ * Permanently delete a note and all its versions 
  */
 export const deleteNote = asyncHandler(async (req, res) => {
+  const noteId = req.params.id;
+  const userId = req.user.id;
+  const clientVersion = req.query.version;
+  
+  // Start a transaction
+  const transaction = await db.sequelize.transaction();
+  
+  try {
+    // Get the note with a lock for update
+    const note = await db.Note.findOne({
+      where: {
+        id: noteId,
+        userId
+      },
+      lock: transaction.LOCK.UPDATE,
+      transaction
+    });
+    
+    if (!note) {
+      await transaction.rollback();
+      return res.status(404).json({ error: 'Note not found' });
+    }
+    
+    // Check for version conflict (optimistic locking)
+    if (parseInt(clientVersion) !== note.version) {
+      await transaction.rollback();
+      return res.status(409).json({
+        error: 'Version conflict. The note has been modified since you last retrieved it.',
+        clientVersion: parseInt(clientVersion),
+        serverVersion: note.version
+      });
+    }
+    
+    // Delete all versions of the note
+    await db.NoteVersion.destroy({
+      where: { noteId },
+      transaction
+    });
+    
+    // Delete the note itself
+    await note.destroy({ transaction });
+    
+    await transaction.commit();
+    
+    // Invalidate all related caches
+    await noteCache.invalidateAllNoteCache(noteId, userId);
+    // Also invalidate search results as they might contain this note
+    await noteCache.invalidateSearchResults(userId);
+    
+    return res.json({ message: 'Note permanently deleted successfully' });
+  } catch (error) {
+    // Only roll back if the transaction is still active
+    if (transaction && !transaction.finished) {
+      await transaction.rollback();
+    }
+    throw error;
+  }
+});
+
+/**
+ * Soft delete a note (marks as deleted but preserves in database)
+ */
+export const softDeleteNote = asyncHandler(async (req, res) => {
   const noteId = req.params.id;
   const userId = req.user.id;
   const clientVersion = req.query.version;
@@ -318,19 +453,36 @@ export const deleteNote = asyncHandler(async (req, res) => {
       return res.status(409).json({
         error: 'Version conflict. The note has been modified since you last retrieved it.',
         clientVersion: parseInt(clientVersion),
-        serverVersion: note.version,
-        message: 'Please refresh and try again'
+        serverVersion: note.version
       });
     }
     
-    // Soft delete by updating isDeleted flag
+    // Increment version for the soft delete operation
+    const newVersion = note.version + 1;
+    
+    // Perform soft delete by setting isDeleted to true
     await note.update({
-      isDeleted: true
+      isDeleted: true,
+      version: newVersion
+    }, { transaction });
+    
+    // Create a version entry for the soft delete action
+    await db.NoteVersion.create({
+      noteId,
+      title: note.title,
+      content: note.content,
+      version: newVersion,
+      createdBy: userId
     }, { transaction });
     
     await transaction.commit();
     
-    return res.json({ message: 'Note deleted successfully' });
+    // Invalidate all related caches
+    await noteCache.invalidateAllNoteCache(noteId, userId);
+    // Also invalidate search results as they might contain this note
+    await noteCache.invalidateSearchResults(userId);
+    
+    return res.json({ message: 'Note soft-deleted successfully' });
   } catch (error) {
     // Only roll back if the transaction is still active
     if (transaction && !transaction.finished) {
@@ -385,33 +537,37 @@ export const resolveConflict = asyncHandler(async (req, res) => {
     }
     
     // Increment version and update note
-    const newVersion = note.version + 1;
+    const latestVersion = parseInt(serverVersion) + 1;
     
-    // Update the note with resolved content
+    // Update the note with resolved content and updated version
     await note.update({
       title,
       content,
-      version: newVersion
+      version: latestVersion
     }, { transaction });
     
-    // Save version history with conflict resolution metadata
+    // Create a version entry for the resolved conflict
     await db.NoteVersion.create({
       noteId,
       title,
       content,
-      version: newVersion,
-      createdBy: userId,
-      metadata: {
-        conflictResolution: resolutionStrategy,
-        resolvedFrom: serverVersion
-      }
+      version: latestVersion,
+      createdBy: userId
     }, { transaction });
     
     await transaction.commit();
     
+    // Invalidate all related caches
+    await noteCache.invalidateAllNoteCache(noteId, userId);
+    // Also invalidate search results as they might contain this note
+    await noteCache.invalidateSearchResults(userId);
+    
     return res.json({
-      message: 'Conflict successfully resolved',
-      note,
+      message: 'Conflict resolved successfully',
+      note: {
+        ...note.toJSON(),
+        version: latestVersion
+      },
       resolutionStrategy
     });
   } catch (error) {

--- a/src/routes/note.js
+++ b/src/routes/note.js
@@ -9,6 +9,7 @@ import {
   updateNote,
   searchNotes,
   deleteNote,
+  softDeleteNote,
   resolveConflict
 } from '../controllers/noteController.js';
 import {
@@ -66,10 +67,16 @@ router.post('/:id/revert/:version', authenticate, validateNoteId, validateRevert
 router.put('/:id', authenticate, validateNoteId, validateUpdateNote, updateNote);
 
 /**
- * Soft delete a note
- * DELETE /notes/:id?version=X
+ * Permanently delete a note and all its versions
+ * DELETE /notes/:id
  */
-router.delete('/:id', authenticate, validateNoteId, validateDeleteNote, deleteNote);
+router.delete('/:id', authenticate, validateNoteId, deleteNote);
+
+/**
+ * Soft delete a note (mark as deleted but preserve in database)
+ * PUT /notes/:id/soft-delete?version=X
+ */
+router.put('/:id/soft-delete', authenticate, validateNoteId, validateDeleteNote, softDeleteNote);
 
 /**
  * Resolve a version conflict

--- a/tests/integration/noteWithCache.test.js
+++ b/tests/integration/noteWithCache.test.js
@@ -1,0 +1,284 @@
+import noteRoutes from '../../src/routes/note.js';
+import { 
+  createTestApp, 
+  createTestRequest, 
+  withAuth,
+  createTestUser,
+  createTestNote
+} from '../utils/testHelpers.js';
+import { db } from '../setup.js';
+
+// Mock Redis client and noteCache
+jest.mock('../../src/cache/redis.js', () => ({
+  __esModule: true,
+  default: {
+    setEx: jest.fn().mockResolvedValue('OK'),
+    get: jest.fn(),
+    del: jest.fn().mockResolvedValue(1),
+    keys: jest.fn().mockResolvedValue([])
+  }
+}));
+
+jest.mock('../../src/cache/noteCache.js', () => ({
+  __esModule: true,
+  default: {
+    getUserNotesKey: jest.fn(userId => `user:${userId}:notes`),
+    getNoteKey: jest.fn(noteId => `note:${noteId}`),
+    getNoteVersionsKey: jest.fn(noteId => `note:${noteId}:versions`),
+    getSearchKey: jest.fn((userId, query) => `user:${userId}:search:${query}`),
+    
+    // Cache operations
+    cacheUserNotes: jest.fn().mockResolvedValue(),
+    getUserNotes: jest.fn(),
+    cacheNote: jest.fn().mockResolvedValue(),
+    getNote: jest.fn(),
+    cacheNoteVersions: jest.fn().mockResolvedValue(),
+    getNoteVersions: jest.fn(),
+    cacheSearchResults: jest.fn().mockResolvedValue(),
+    getSearchResults: jest.fn(),
+    
+    // Cache invalidation
+    invalidateUserNotes: jest.fn().mockResolvedValue(),
+    invalidateNote: jest.fn().mockResolvedValue(),
+    invalidateNoteVersions: jest.fn().mockResolvedValue(),
+    invalidateAllNoteCache: jest.fn().mockResolvedValue(),
+    invalidateSearchResults: jest.fn().mockResolvedValue()
+  }
+}));
+
+import redisClient from '../../src/cache/redis.js';
+import noteCache from '../../src/cache/noteCache.js';
+
+// Create test app for authenticated routes
+const app = createTestApp({
+  routesPath: noteRoutes,
+  routePrefix: '/notes',
+  useAuth: true
+});
+
+// Create request object
+const request = createTestRequest(app);
+
+describe('Note Routes with Redis Cache', () => {
+  let testUser;
+
+  beforeEach(async () => {
+    // Reset all mocks
+    jest.clearAllMocks();
+    
+    // Create a test user for the tests
+    testUser = await createTestUser();
+  });
+
+  describe('GET /notes (getAllNotes)', () => {
+    it('should return notes from cache when available', async () => {
+      const cachedNotes = [
+        { id: 1, title: 'Cached Note 1', content: 'Cached content 1', userId: testUser.id },
+        { id: 2, title: 'Cached Note 2', content: 'Cached content 2', userId: testUser.id }
+      ];
+      
+      // Setup the cache to return notes
+      noteCache.getUserNotes.mockResolvedValueOnce(cachedNotes);
+      
+      const res = await withAuth(
+        request.get('/notes'),
+        testUser
+      );
+      
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual(cachedNotes);
+      expect(noteCache.getUserNotes).toHaveBeenCalledWith(testUser.id);
+      
+      // Verify that we didn't query the database
+      expect(noteCache.cacheUserNotes).not.toHaveBeenCalled();
+    });
+    
+    it('should fetch from database and cache when cache is empty', async () => {
+      // Create some test notes in the database
+      const note1 = await createTestNote(testUser.id);
+      const note2 = await createTestNote(testUser.id);
+      
+      // Setup cache miss
+      noteCache.getUserNotes.mockResolvedValueOnce(null);
+      
+      const res = await withAuth(
+        request.get('/notes'),
+        testUser
+      );
+      
+      expect(res.statusCode).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThanOrEqual(2);
+      
+      // Verify that the result was cached
+      expect(noteCache.cacheUserNotes).toHaveBeenCalledWith(
+        testUser.id,
+        expect.arrayContaining([
+          expect.objectContaining({ id: note1.id }),
+          expect.objectContaining({ id: note2.id })
+        ])
+      );
+    });
+  });
+  
+  describe('GET /notes/:id (getNoteById)', () => {
+    it('should return a note from cache when available', async () => {
+      const note = await createTestNote(testUser.id);
+      const cachedNote = { 
+        id: note.id, 
+        title: 'Cached Note', 
+        content: 'Cached content', 
+        userId: testUser.id,
+        isDeleted: false
+      };
+      
+      // Setup cache hit
+      noteCache.getNote.mockResolvedValueOnce(cachedNote);
+      
+      const res = await withAuth(
+        request.get(`/notes/${note.id}`),
+        testUser
+      );
+      
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual(cachedNote);
+      expect(noteCache.getNote).toHaveBeenCalledWith(note.id.toString());
+    });
+    
+    it('should fetch from database and cache when note is not in cache', async () => {
+      const note = await createTestNote(testUser.id);
+      
+      // Setup cache miss
+      noteCache.getNote.mockResolvedValueOnce(null);
+      
+      const res = await withAuth(
+        request.get(`/notes/${note.id}`),
+        testUser
+      );
+      
+      expect(res.statusCode).toBe(200);
+      expect(res.body.id).toBe(note.id);
+      
+      // Verify note was cached
+      expect(noteCache.cacheNote).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: note.id
+        })
+      );
+    });
+  });
+  
+  describe('POST /notes (createNote)', () => {
+    it('should invalidate user notes cache after creating a note', async () => {
+      const noteData = {
+        title: 'Test Note',
+        content: 'This is a test note content'
+      };
+      
+      const res = await withAuth(
+        request.post('/notes').send(noteData),
+        testUser
+      );
+      
+      expect(res.statusCode).toBe(201);
+      
+      // Verify cache invalidation
+      expect(noteCache.invalidateUserNotes).toHaveBeenCalledWith(testUser.id);
+    });
+  });
+  
+  describe('PUT /notes/:id (updateNote)', () => {
+    it('should invalidate all related caches after updating a note', async () => {
+      const note = await createTestNote(testUser.id);
+      const updateData = {
+        title: 'Updated Title',
+        content: 'Updated content',
+        version: note.version
+      };
+      
+      const res = await withAuth(
+        request.put(`/notes/${note.id}`).send(updateData),
+        testUser
+      );
+      
+      expect(res.statusCode).toBe(200);
+      
+      // Verify cache invalidation
+      expect(noteCache.invalidateAllNoteCache).toHaveBeenCalledWith(
+        note.id.toString(),
+        testUser.id
+      );
+    });
+  });
+  
+  describe('DELETE /notes/:id (deleteNote)', () => {
+    it('should invalidate all related caches after deleting a note', async () => {
+      const note = await createTestNote(testUser.id);
+      
+      const res = await withAuth(
+        request.delete(`/notes/${note.id}?version=${note.version}`),
+        testUser
+      );
+      
+      expect(res.statusCode).toBe(200);
+      
+      // Verify cache invalidation
+      expect(noteCache.invalidateAllNoteCache).toHaveBeenCalledWith(
+        note.id.toString(),
+        testUser.id
+      );
+      expect(noteCache.invalidateSearchResults).toHaveBeenCalledWith(testUser.id);
+    });
+  });
+  
+  describe('GET /notes/search (searchNotes)', () => {
+    it('should return search results from cache when available', async () => {
+      const cachedResults = [
+        { id: 1, title: 'Test Note', content: 'Search term match', userId: testUser.id }
+      ];
+      
+      // Setup cache hit
+      noteCache.getSearchResults.mockResolvedValueOnce(cachedResults);
+      
+      const res = await withAuth(
+        request.get('/notes/search?q=search'),
+        testUser
+      );
+      
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual(cachedResults);
+      expect(noteCache.getSearchResults).toHaveBeenCalledWith(testUser.id, 'search');
+    });
+    
+    it('should search in database and cache when results not in cache', async () => {
+      // Create a note with searchable content
+      await createTestNote(testUser.id, {
+        title: 'Unique Search Title',
+        content: 'Unique search content to find'
+      });
+      
+      // Setup cache miss
+      noteCache.getSearchResults.mockResolvedValueOnce(null);
+      
+      const res = await withAuth(
+        request.get('/notes/search?q=unique'),
+        testUser
+      );
+      
+      expect(res.statusCode).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      
+      // Verify search results were cached
+      expect(noteCache.cacheSearchResults).toHaveBeenCalledWith(
+        testUser.id,
+        'unique',
+        expect.arrayContaining([
+          expect.objectContaining({
+            title: 'Unique Search Title',
+            content: 'Unique search content to find'
+          })
+        ])
+      );
+    });
+  });
+});

--- a/tests/integration/noteWithCache.test.js
+++ b/tests/integration/noteWithCache.test.js
@@ -8,16 +8,6 @@ import {
 } from '../utils/testHelpers.js';
 import { db } from '../setup.js';
 
-// Mock Redis client and noteCache
-jest.mock('../../src/cache/redis.js', () => ({
-  __esModule: true,
-  default: {
-    setEx: jest.fn().mockResolvedValue('OK'),
-    get: jest.fn(),
-    del: jest.fn().mockResolvedValue(1),
-    keys: jest.fn().mockResolvedValue([])
-  }
-}));
 
 jest.mock('../../src/cache/noteCache.js', () => ({
   __esModule: true,

--- a/tests/setupRedisMock.js
+++ b/tests/setupRedisMock.js
@@ -1,0 +1,17 @@
+// Mock redis client for all tests
+jest.mock('../src/cache/redis.js', () => ({
+    __esModule: true,
+    default: {
+      connect: jest.fn().mockResolvedValue(true),
+      setEx: jest.fn().mockResolvedValue('OK'),
+      get: jest.fn().mockImplementation((key) => {
+        // You can implement more sophisticated caching behavior if needed
+        return Promise.resolve(null);
+      }),
+      del: jest.fn().mockResolvedValue(1),
+      keys: jest.fn().mockResolvedValue([]),
+      on: jest.fn(),
+      isReady: true
+    }
+  }))
+  

--- a/tests/unit/cache/noteCache.test.js
+++ b/tests/unit/cache/noteCache.test.js
@@ -1,0 +1,231 @@
+import { jest } from '@jest/globals';
+
+// Mock the redis client
+jest.mock('../../../src/cache/redis.js', () => ({
+  __esModule: true,
+  default: {
+    setEx: jest.fn().mockResolvedValue('OK'),
+    get: jest.fn(),
+    del: jest.fn().mockResolvedValue(1),
+    keys: jest.fn().mockResolvedValue([])
+  }
+}));
+
+import redisClient from '../../../src/cache/redis.js';
+import noteCache from '../../../src/cache/noteCache.js';
+
+describe('Note Cache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Key Generation', () => {
+    it('should generate correct user notes key', () => {
+      const userId = 123;
+      const key = noteCache.getUserNotesKey(userId);
+      expect(key).toBe('user:123:notes');
+    });
+
+    it('should generate correct note key', () => {
+      const noteId = 456;
+      const key = noteCache.getNoteKey(noteId);
+      expect(key).toBe('note:456');
+    });
+
+    it('should generate correct note versions key', () => {
+      const noteId = 789;
+      const key = noteCache.getNoteVersionsKey(noteId);
+      expect(key).toBe('note:789:versions');
+    });
+
+    it('should generate correct search key', () => {
+      const userId = 123;
+      const query = 'test query';
+      const key = noteCache.getSearchKey(userId, query);
+      expect(key).toBe('user:123:search:test query');
+    });
+  });
+
+  describe('Cache Operations', () => {
+    const userId = 123;
+    const noteId = 456;
+    const mockNote = { id: noteId, title: 'Test Note', userId };
+    const mockNotes = [mockNote];
+    const mockVersions = [{ id: 1, noteId, version: 1 }];
+    const mockSearchQuery = 'test';
+    const mockSearchResults = [mockNote];
+
+    describe('User Notes', () => {
+      it('should cache user notes successfully', async () => {
+        await noteCache.cacheUserNotes(userId, mockNotes);
+        
+        expect(redisClient.setEx).toHaveBeenCalledWith(
+          `user:${userId}:notes`,
+          expect.any(Number),
+          JSON.stringify(mockNotes)
+        );
+      });
+
+      it('should get user notes from cache when available', async () => {
+        redisClient.get.mockResolvedValueOnce(JSON.stringify(mockNotes));
+        
+        const result = await noteCache.getUserNotes(userId);
+        
+        expect(redisClient.get).toHaveBeenCalledWith(`user:${userId}:notes`);
+        expect(result).toEqual(mockNotes);
+      });
+
+      it('should return null when user notes not in cache', async () => {
+        redisClient.get.mockResolvedValueOnce(null);
+        
+        const result = await noteCache.getUserNotes(userId);
+        
+        expect(redisClient.get).toHaveBeenCalledWith(`user:${userId}:notes`);
+        expect(result).toBeNull();
+      });
+
+      it('should handle errors when caching user notes', async () => {
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+        redisClient.setEx.mockRejectedValueOnce(new Error('Redis error'));
+        
+        await noteCache.cacheUserNotes(userId, mockNotes);
+        
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        consoleErrorSpy.mockRestore();
+      });
+    });
+
+    describe('Individual Notes', () => {
+      it('should cache a note successfully', async () => {
+        await noteCache.cacheNote(mockNote);
+        
+        expect(redisClient.setEx).toHaveBeenCalledWith(
+          `note:${noteId}`,
+          expect.any(Number),
+          JSON.stringify(mockNote)
+        );
+      });
+
+      it('should get a note from cache when available', async () => {
+        redisClient.get.mockResolvedValueOnce(JSON.stringify(mockNote));
+        
+        const result = await noteCache.getNote(noteId);
+        
+        expect(redisClient.get).toHaveBeenCalledWith(`note:${noteId}`);
+        expect(result).toEqual(mockNote);
+      });
+
+      it('should return null when note not in cache', async () => {
+        redisClient.get.mockResolvedValueOnce(null);
+        
+        const result = await noteCache.getNote(noteId);
+        
+        expect(redisClient.get).toHaveBeenCalledWith(`note:${noteId}`);
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('Note Versions', () => {
+      it('should cache note versions successfully', async () => {
+        await noteCache.cacheNoteVersions(noteId, mockVersions);
+        
+        expect(redisClient.setEx).toHaveBeenCalledWith(
+          `note:${noteId}:versions`,
+          expect.any(Number),
+          JSON.stringify(mockVersions)
+        );
+      });
+
+      it('should get note versions from cache when available', async () => {
+        redisClient.get.mockResolvedValueOnce(JSON.stringify(mockVersions));
+        
+        const result = await noteCache.getNoteVersions(noteId);
+        
+        expect(redisClient.get).toHaveBeenCalledWith(`note:${noteId}:versions`);
+        expect(result).toEqual(mockVersions);
+      });
+    });
+
+    describe('Search Results', () => {
+      it('should cache search results successfully', async () => {
+        await noteCache.cacheSearchResults(userId, mockSearchQuery, mockSearchResults);
+        
+        expect(redisClient.setEx).toHaveBeenCalledWith(
+          `user:${userId}:search:${mockSearchQuery}`,
+          expect.any(Number),
+          JSON.stringify(mockSearchResults)
+        );
+      });
+
+      it('should get search results from cache when available', async () => {
+        redisClient.get.mockResolvedValueOnce(JSON.stringify(mockSearchResults));
+        
+        const result = await noteCache.getSearchResults(userId, mockSearchQuery);
+        
+        expect(redisClient.get).toHaveBeenCalledWith(`user:${userId}:search:${mockSearchQuery}`);
+        expect(result).toEqual(mockSearchResults);
+      });
+    });
+  });
+
+  describe('Cache Invalidation', () => {
+    const userId = 123;
+    const noteId = 456;
+
+    it('should invalidate user notes cache', async () => {
+      await noteCache.invalidateUserNotes(userId);
+      
+      expect(redisClient.del).toHaveBeenCalledWith(`user:${userId}:notes`);
+    });
+
+    it('should invalidate note cache', async () => {
+      await noteCache.invalidateNote(noteId);
+      
+      expect(redisClient.del).toHaveBeenCalledWith(`note:${noteId}`);
+    });
+
+    it('should invalidate note versions cache', async () => {
+      await noteCache.invalidateNoteVersions(noteId);
+      
+      expect(redisClient.del).toHaveBeenCalledWith(`note:${noteId}:versions`);
+    });
+
+    it('should invalidate all note caches', async () => {
+      await noteCache.invalidateAllNoteCache(noteId, userId);
+      
+      expect(redisClient.del).toHaveBeenCalledTimes(3);
+    });
+
+    it('should invalidate search results cache', async () => {
+      const mockSearchKeys = [`user:${userId}:search:test1`, `user:${userId}:search:test2`];
+      redisClient.keys.mockResolvedValueOnce(mockSearchKeys);
+      
+      await noteCache.invalidateSearchResults(userId);
+      
+      expect(redisClient.keys).toHaveBeenCalledWith(`user:${userId}:search:*`);
+      expect(redisClient.del).toHaveBeenCalledWith(mockSearchKeys);
+    });
+
+    it('should handle empty search results when invalidating', async () => {
+      redisClient.keys.mockResolvedValueOnce([]);
+      
+      await noteCache.invalidateSearchResults(userId);
+      
+      expect(redisClient.keys).toHaveBeenCalledWith(`user:${userId}:search:*`);
+      expect(redisClient.del).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle Redis errors gracefully', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      redisClient.get.mockRejectedValueOnce(new Error('Redis error'));
+      
+      const result = await noteCache.getNote(123);
+      
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/cache/noteCache.test.js
+++ b/tests/unit/cache/noteCache.test.js
@@ -1,16 +1,5 @@
 import { jest } from '@jest/globals';
 
-// Mock the redis client
-jest.mock('../../../src/cache/redis.js', () => ({
-  __esModule: true,
-  default: {
-    setEx: jest.fn().mockResolvedValue('OK'),
-    get: jest.fn(),
-    del: jest.fn().mockResolvedValue(1),
-    keys: jest.fn().mockResolvedValue([])
-  }
-}));
-
 import redisClient from '../../../src/cache/redis.js';
 import noteCache from '../../../src/cache/noteCache.js';
 


### PR DESCRIPTION
# Added the redis cache functionality to notes
`Redis database connection was initialized before but not implemented in notes`
- Added `noteCache.js` class to handle the function logic of how to handle caching
- Updated the notes controller to implement said functions on retrieval, update and delete, invalidating and updating cache as necessary
- Added supporting tests
- Also modified the delete endpoint to delete the entire note, adding a seperate `soft delete` endpoint that will properly soft delete the note for historical tracking